### PR TITLE
ci: Add ci optimization

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,8 +12,21 @@ permissions:
   issues: write
 
 jobs:
+  optimize_ci:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@main
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_TOKEN }}
+  
   release-please:
-    runs-on: ubuntu
+    runs-on: ubuntu-latest
+    needs: optimize_ci
+    if: needs.optimize_ci.outputs.skip == 'false'
     steps:
       - name: Release
         uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0


### PR DESCRIPTION
### TL;DR

Added Graphite CI optimization to the release-please workflow to skip unnecessary runs.

### What changed?

- Added a new `optimize_ci` job that uses the Graphite CI action to determine if the workflow should run
- Made the `release-please` job depend on the optimization job and only run when not skipped
- Updated the runner from `ubuntu` to `ubuntu-latest` for the release-please job

### How to test?

1. Verify that the workflow runs correctly when changes are pushed to the main branch
2. Confirm that the Graphite CI action correctly identifies when to skip the release-please job
3. Ensure the `GRAPHITE_TOKEN` secret is properly configured in the repository settings

### Why make this change?

This change optimizes CI resources by skipping unnecessary release-please workflow runs when there are no relevant changes. This reduces CI costs and execution time while maintaining the same functionality when actual releases are needed.